### PR TITLE
remove default adapters from somatic

### DIFF
--- a/somatic.wdl
+++ b/somatic.wdl
@@ -55,8 +55,8 @@ workflow Somatic {
         File? regions
         File? cnvPanelOfNormals
         File? preprocessedIntervals
-        String? adapterForward = "AGATCGGAAGAG"  # Illumina universal adapter.
-        String? adapterReverse = "AGATCGGAAGAG"  # Illumina universal adapter.
+        String? adapterForward
+        String? adapterReverse
         Int? cnvMinimumContigLength
         Int? scatterSize
         File? commonVariantSites


### PR DESCRIPTION
The default adapters were removed for germline.wdl in #91, they should also have been removed from somatic.wdl

### Checklist
- [ ] Pull request details were added to CHANGELOG.md.
- [ ] Documentation was updated (if required).
- [ ] Workflow `parameter_meta` was added/updated (if required).
- [ ] Submodule branches are on develop or a tagged commit.
